### PR TITLE
Remove unnecessary DigestMethod().Reset() calls

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -19,7 +19,6 @@ type HMACAlgorithm struct {
 
 // GetSignature returns the signature for the given key and value.
 func (a *HMACAlgorithm) GetSignature(key, value string) []byte {
-	a.DigestMethod().Reset()
 	h := hmac.New(func() hash.Hash { return a.DigestMethod() }, []byte(key))
 	h.Write([]byte(value))
 	return h.Sum(nil)

--- a/algorithm.go
+++ b/algorithm.go
@@ -19,7 +19,7 @@ type HMACAlgorithm struct {
 
 // GetSignature returns the signature for the given key and value.
 func (a *HMACAlgorithm) GetSignature(key, value string) []byte {
-	h := hmac.New(func() hash.Hash { return a.DigestMethod() }, []byte(key))
+	h := hmac.New(a.DigestMethod, []byte(key))
 	h.Write([]byte(value))
 	return h.Sum(nil)
 }

--- a/signature.go
+++ b/signature.go
@@ -45,7 +45,7 @@ func (s *Signature) DeriveKey() (string, error) {
 		h.Write([]byte(s.Salt + "signer" + s.SecretKey))
 		key = string(h.Sum(nil))
 	case "hmac":
-		h := hmac.New(func() hash.Hash { return s.DigestMethod() }, []byte(s.SecretKey))
+		h := hmac.New(s.DigestMethod, []byte(s.SecretKey))
 		h.Write([]byte(s.Salt))
 		key = string(h.Sum(nil))
 	case "none":

--- a/signature.go
+++ b/signature.go
@@ -35,8 +35,6 @@ func (s *Signature) DeriveKey() (string, error) {
 	var key string
 	var err error
 
-	s.DigestMethod().Reset()
-
 	switch s.KeyDerivation {
 	case "concat":
 		h := s.DigestMethod()


### PR DESCRIPTION
These simply generate a new hash instance, only to call `Reset()` on it and then discard it, which is a wasted allocation etc.

They look to be a hangover from before #3 where DigestMethod used to hold a persistent instance of `hash.Hash`, and therefore needed resetting before each use.

While here, I've also removed an unnecessary anonymous function. `DigestMethod` is already a `func() hash.Hash`, so there's no need to wrap it in an anonymous function with the same signature to call it.